### PR TITLE
Singular PathParameter instead of PathParameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,8 @@ Extract path wildcard values via the request context.
 
 ```go
 func getPostHandler(w http.ResponseWriter, r *http.Request) {
-    pathParameters := gemux.PathParameters(r.Context())
-    if len(pathParameters) != 1 {
-        http.Error(w, "got an unexpected number of path parameters, the muxer is broken", http.StatusInternalServerError)
-        return
-    }
-
-    postID, err := strconv.ParseInt(pathParameters[0], 10, 64)
+    rawPostID := gemux.PathParameter(r.Context(), 0)
+    postID, err := strconv.ParseInt(rawPostID, 10, 64)
     if err != nil {
         http.Error(w, err.Error(), http.StatusBadRequest)
         return


### PR DESCRIPTION
Probably marginally slower since you're having to get all path parameters from the context each time you get a path parameter, but it shouldn't matter. I think this API is a lot nicer, especially since it returns an empty string when the index isn't found.

The release for this change should increment the minor version since this is a breaking change but we're still on MAJOR version 0 (this isn't the final public API).